### PR TITLE
Update packages.x86_64

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -178,6 +178,7 @@ wget
 xdg-user-dirs-gtk
 xz
 gpm
+gnome-keyring
 
 # network.packages
 #b43-firmware


### PR DESCRIPTION
Add gnome-keyring package, needed for ssh