### PR TITLE
Security improvements

### DIFF
--- a/airootfs/etc/iptables/iptables.rules
+++ b/airootfs/etc/iptables/iptables.rules
@@ -1,0 +1,11 @@
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+-A INPUT -p icmp -j ACCEPT 
+-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 
+-A INPUT -i lo -j ACCEPT 
+-A INPUT -p tcp -j REJECT --reject-with tcp-reset 
+-A INPUT -p udp -j REJECT --reject-with icmp-port-unreachable 
+-A INPUT -j REJECT --reject-with icmp-proto-unreachable 
+COMMIT

--- a/airootfs/root/customize_airootfs.sh
+++ b/airootfs/root/customize_airootfs.sh
@@ -33,7 +33,6 @@ chown root:root /etc/sudoers.d
 chown root:root /etc/sudoers.d/g_wheel
 chmod 755 /etc
 
-sed -i 's/#\(PermitRootLogin \).\+/\1yes/' /etc/ssh/sshd_config
 sed -i "s/#Server/Server/g" /etc/pacman.d/mirrorlist
 sed -i 's/#\(Storage=\)auto/\1volatile/' /etc/systemd/journald.conf
 

--- a/airootfs/root/customize_airootfs.sh
+++ b/airootfs/root/customize_airootfs.sh
@@ -40,5 +40,5 @@ sed -i 's/#\(HandleSuspendKey=\)suspend/\1ignore/' /etc/systemd/logind.conf
 sed -i 's/#\(HandleHibernateKey=\)hibernate/\1ignore/' /etc/systemd/logind.conf
 sed -i 's/#\(HandleLidSwitch=\)suspend/\1ignore/' /etc/systemd/logind.conf
 
-systemctl enable NetworkManager.service vboxservice.service vmtoolsd.service vmware-vmblock-fuse.service systemd-networkd-wait-online systemd-timesyncd
+systemctl enable iptables.service NetworkManager.service vboxservice.service vmtoolsd.service vmware-vmblock-fuse.service systemd-networkd-wait-online systemd-timesyncd
 systemctl set-default multi-user.target

--- a/packages.x86_64
+++ b/packages.x86_64
@@ -202,6 +202,7 @@ gnome-keyring
 b43-fwcutter
 broadcom-wl-dkms
 dnsutils
+iptables
 ipw2100-fw
 ipw2200-fw
 modemmanager


### PR DESCRIPTION
**root SSH access is enabled by default:** although the SSH service is not set to auto start, root access should be disabled by default.
With no firewall rules shipped with the OS by default, and so all inbound connections are permitted, this is a potential attack vector to users.

**Enable simple stateful firewall:** include the 'simple_firewall.rules' which ship with Arch to only allow established/related inbound connections